### PR TITLE
Webpack 설정 오류 해결

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,16 +1,14 @@
 import React from 'react';
 import { Routes, Route } from 'react-router-dom';
 import loadable from '@loadable/component';
-import useToken from './hooks/useToken';
+import useToken from '@hooks/useToken';
 
-const Home = loadable(() => import('./pages/home/Index'));
-const Login = loadable(() => import('./pages/login/Index'));
-const Register = loadable(() => import('./pages/register/Index'));
-const Auth = loadable(() => import('./components/Auth'));
-const NotFound = loadable(() => import('./components/NotFound'));
-const CertificationEmail = loadable(() =>
-  import('./pages/register/CertificationEmail'),
-);
+const Home = loadable(() => import('@pages/home/Index'));
+const Login = loadable(() => import('@pages/login/Index'));
+const Register = loadable(() => import('@pages/register/Index'));
+const Auth = loadable(() => import('@components/Auth'));
+const NotFound = loadable(() => import('@components/NotFound'));
+const Email = loadable(() => import('@pages/register/certification/Email'));
 
 const App = () => {
   const accessToken = useToken();
@@ -23,7 +21,7 @@ const App = () => {
         <Route path='/' element={<Login />} />
       )}
       <Route path='/register' element={<Register />} />
-      <Route Path='/register/certification' element={<CertificationEmail />} />
+      <Route Path='/register/certification' element={<Email />} />
       <Route path='/oauth/:provider/*' element={<Auth />} />
       <Route path='/*' element={<NotFound />} />
     </Routes>

--- a/src/App.js
+++ b/src/App.js
@@ -21,7 +21,7 @@ const App = () => {
         <Route path='/' element={<Login />} />
       )}
       <Route path='/register' element={<Register />} />
-      <Route Path='/register/certification' element={<Email />} />
+      <Route path='/register/certification' element={<Email />} />
       <Route path='/oauth/:provider/*' element={<Auth />} />
       <Route path='/*' element={<NotFound />} />
     </Routes>

--- a/src/components/Auth.js
+++ b/src/components/Auth.js
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { socialLogin } from '../services/user';
-import { setTokens } from '../utils/auth';
+import { socialLogin } from '@services/user';
+import { setTokens } from '@utils/auth';
 
 const Auth = () => {
   const navigate = useNavigate();

--- a/src/hooks/useInputValidator.js
+++ b/src/hooks/useInputValidator.js
@@ -1,11 +1,11 @@
 import { useCallback, useState } from 'react';
-import { findOne } from '../services/user';
+import { findOne } from '@services/user';
 import {
   regExpName,
   regExpEmail,
   regExpPassword,
   regExpNickname,
-} from '../constants/regExp';
+} from '@constants/regExp';
 import {
   NAME,
   EMAIL,
@@ -13,7 +13,7 @@ import {
   PASSWORD,
   CPASSWORD,
   AXIOSERROR,
-} from '../constants/registerType';
+} from '@constants/registerType';
 
 export function validate({ name, email, nickname, password, cpassword }) {
   let isValid = true;

--- a/src/hooks/useToken.js
+++ b/src/hooks/useToken.js
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
-import { getAccessToken, getRefreshToken, setAccessToken } from '../utils/auth';
-import { reIssue } from '../services/user'; // assume this is the function that issues new tokens
+import { getAccessToken, getRefreshToken, setAccessToken } from '@utils/auth';
+import { reIssue } from '@services/user'; // assume this is the function that issues new tokens
 
 const useToken = () => {
   const [accessToken, setAccessTokenState] = useState(getAccessToken());

--- a/src/pages/home/Index.js
+++ b/src/pages/home/Index.js
@@ -1,9 +1,9 @@
 import React from 'react';
-import { getAccessToken, removeTokens } from '../../utils/auth';
-import { logout } from '../../services/user';
+import { getAccessToken, removeTokens } from '@utils/auth';
+import { logout } from '@services/user';
 import Nav from './Nav';
 import Article from './Article';
-import '../../styles/home/Nav.scss';
+import '@styles/home/Nav.scss';
 
 const Index = () => {
   const onRemove = async () => {

--- a/src/pages/login/Index.js
+++ b/src/pages/login/Index.js
@@ -1,7 +1,7 @@
 import LoginContainer from './LoginContainer';
 import SocialLogin from './SocialLogin';
 import Title from './Title';
-import '../../styles/login/login.scss';
+import '@styles/login/login.scss';
 import React from 'react';
 
 const Index = () => {

--- a/src/pages/login/Login.js
+++ b/src/pages/login/Login.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import loadable from '@loadable/component';
 
-const Register = loadable(() => import('../register/Index'));
+const Register = loadable(() => import('@pages/register/Index'));
 
 const Login = ({ form, onInput, onLogin, error }) => {
   const { email, password } = form;

--- a/src/pages/login/LoginContainer.js
+++ b/src/pages/login/LoginContainer.js
@@ -1,9 +1,9 @@
 import Login from './Login';
 import { useCallback, useState } from 'react';
-import { login } from '../../services/user';
-import { regExpSpace } from '../../constants/regExp';
-import { useInitialState } from '../../hooks/useInitialState';
-import { setTokens } from '../../utils/auth';
+import { login } from '@services/user';
+import { regExpSpace } from '@constants/regExp';
+import { useInitialState } from '@hooks/useInitialState';
+import { setTokens } from '@utils/auth';
 
 const LoginContainer = () => {
   const [form, setForm, resetForm] = useInitialState({

--- a/src/pages/login/SocialLogin.js
+++ b/src/pages/login/SocialLogin.js
@@ -1,13 +1,9 @@
 import React from 'react';
 import loadable from '@loadable/component';
 import { Link } from 'react-router-dom';
-import {
-  GOOGLE_AUTH_URL,
-  KAKAO_AUTH_URL,
-  NAVER_AUTH_URL,
-} from '../../config/auth';
+import { GOOGLE_AUTH_URL, KAKAO_AUTH_URL, NAVER_AUTH_URL } from '@config/auth';
 
-const Auth = loadable(() => import('../../components/Auth'));
+const Auth = loadable(() => import('@components/Auth'));
 
 const SocialLogin = () => {
   const onAuthLoad = () => Auth.preload();

--- a/src/pages/login/Title.js
+++ b/src/pages/login/Title.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import Logo from '../../assets/Logo.png';
+import Logo from '@assets/Logo.png';
 
 const Title = () => {
   return (

--- a/src/pages/register/Checkbox.js
+++ b/src/pages/register/Checkbox.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import '../../styles/register/register.scss';
+import '@styles/register/register.scss';
 
 function Checkbox({ children, disabled, checked, onChange }) {
   return (

--- a/src/pages/register/Index.js
+++ b/src/pages/register/Index.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import Title from './Title';
 import RegisterContainer from './RegisterContainer';
-import CertificationEmail from './CertificationEmail';
 
 const Index = () => {
   return (

--- a/src/pages/register/Register.js
+++ b/src/pages/register/Register.js
@@ -1,6 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
 import '@styles/register/register.scss';
-import { Link } from 'react-router-dom';
 import Checkbox from './Checkbox';
 
 const Register = ({ form, messages, onInput, onCheck, onRegister }) => {
@@ -121,7 +120,6 @@ const Register = ({ form, messages, onInput, onCheck, onRegister }) => {
         </div>
       </div>
       <div className='check_assign'>
-        {/* 필수 누르면 가입하기 버튼 활성화 원래는 활성화 x -> 이거 내가 만들거 */}
         <Checkbox checked={service} onChange={setService}>
           <span>(필수) 서비스 이용약관</span>
         </Checkbox>
@@ -129,15 +127,13 @@ const Register = ({ form, messages, onInput, onCheck, onRegister }) => {
           <span>(선택) 개인정보 이용</span>
         </Checkbox>
         <div className='signbtn'>
-          <Link to='./certificationemail'>
-            <button
-              type='submit'
-              className={service ? 'check_btn' : 'Ncheck_btn'}
-              disabled={!service}
-            >
-              가입하기
-            </button>
-          </Link>
+          <button
+            type='submit'
+            className={service ? 'check_btn' : 'Ncheck_btn'}
+            disabled={!service}
+          >
+            가입하기
+          </button>
         </div>
       </div>
       {messages.axiosError && (

--- a/src/pages/register/Register.js
+++ b/src/pages/register/Register.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
-import '../../styles/register/register.scss';
+import '@styles/register/register.scss';
 import { Link } from 'react-router-dom';
 import Checkbox from './Checkbox';
 

--- a/src/pages/register/RegisterContainer.js
+++ b/src/pages/register/RegisterContainer.js
@@ -1,11 +1,11 @@
 import { useCallback } from 'react';
 import Register from './Register';
-import CertificationEmail from './CertificationEmail';
+import Email from './certification/Email';
 import { Route, Routes, useNavigate } from 'react-router-dom';
-import { register } from '../../services/user';
-import { regExpSpace } from '../../constants/regExp';
-import useInputValidator, { validate } from '../../hooks/useInputValidator';
-import { useInitialState } from '../../hooks/useInitialState';
+import { register } from '@services/user';
+import { regExpSpace } from '@constants/regExp';
+import useInputValidator, { validate } from '@hooks/useInputValidator';
+import { useInitialState } from '@hooks/useInitialState';
 
 const RegisterContainer = () => {
   const { messages, validateInput } = useInputValidator();
@@ -40,7 +40,6 @@ const RegisterContainer = () => {
     async (e) => {
       e.preventDefault();
 
-      navigate('./certification');
       try {
         if (validate(form)) {
           delete form.cpassword;
@@ -66,10 +65,7 @@ const RegisterContainer = () => {
         onRegister={onRegister}
       />
       <Routes>
-        <Route
-          Path='/register/certification'
-          element={<CertificationEmail />}
-        />
+        <Route Path='/register/certification' element={<Email />} />
       </Routes>
     </>
   );

--- a/src/pages/register/RegisterContainer.js
+++ b/src/pages/register/RegisterContainer.js
@@ -1,11 +1,13 @@
 import { useCallback } from 'react';
 import Register from './Register';
-import Email from './certification/Email';
-import { Route, Routes, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { register } from '@services/user';
 import { regExpSpace } from '@constants/regExp';
 import useInputValidator, { validate } from '@hooks/useInputValidator';
 import { useInitialState } from '@hooks/useInitialState';
+import loadable from '@loadable/component';
+
+const Email = loadable(() => import('./certification/Email'));
 
 const RegisterContainer = () => {
   const { messages, validateInput } = useInputValidator();
@@ -38,6 +40,7 @@ const RegisterContainer = () => {
 
   const onRegister = useCallback(
     async (e) => {
+      Email.preload();
       e.preventDefault();
 
       try {
@@ -46,7 +49,7 @@ const RegisterContainer = () => {
           await register(form);
 
           resetForm();
-          navigate('./certification');
+          navigate('/register/certification');
         }
       } catch (e) {
         await validateInput('axiosError', e.message);
@@ -56,18 +59,13 @@ const RegisterContainer = () => {
   );
 
   return (
-    <>
-      <Register
-        form={form}
-        messages={messages}
-        onInput={onInput}
-        onCheck={onCheck}
-        onRegister={onRegister}
-      />
-      <Routes>
-        <Route Path='/register/certification' element={<Email />} />
-      </Routes>
-    </>
+    <Register
+      form={form}
+      messages={messages}
+      onInput={onInput}
+      onCheck={onCheck}
+      onRegister={onRegister}
+    />
   );
 };
 

--- a/src/pages/register/Title.js
+++ b/src/pages/register/Title.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import '../../styles/register/register.scss';
-import Logo from '../../assets/Logo.png';
+import '@styles/register/register.scss';
+import Logo from '@assets/Logo.png';
 
 const Title = () => {
   return (

--- a/src/pages/register/certification/Email.js
+++ b/src/pages/register/certification/Email.js
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
-import Title from './Title';
-import '../../styles/register/register.scss';
-import GoogleLogo from '../../assets/googleLogo.png';
+import Title from '../Title';
+import '@styles/register/register.scss';
+import GoogleLogo from '@assets/googleLogo.png';
 
 const CertificationEmail = () => {
   const [send, setSend] = useState('false');

--- a/src/services/user.js
+++ b/src/services/user.js
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { MAIN_SERVER } from '../config/user';
+import { MAIN_SERVER } from '@config/user';
 
 /**
  * auth findOne 함수

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,30 +16,14 @@ const config = {
   entry: './src/index.js',
   output: {
     path: path.resolve(__dirname, 'build'),
+    publicPath: '/',
   },
   devServer: {
     open: true,
     host: process.env.REACT_APP_DOMAIN,
     port: process.env.REACT_APP_PORT,
     hot: true,
-    headers: {
-      'Access-Control-Allow-Origin': '*',
-      'Access-Control-Allow-Credentials': 'true',
-      'Access-Control-Max-Age': '3600',
-      'Access-Control-Allow-Headers':
-        'Content-Type, Authorization, x-id, Content-Length, X-Requested-With',
-      'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
-    },
-    proxy: {
-      '/api/auth/social': {
-        target: 'http://165.229.86.126:8080/oauth/:provider/callback',
-        changeOrigin: true,
-        secure: false,
-        bypass: function (req, res, proxyOptions) {
-          console.info(req.method + ' ' + req.originalUrl);
-        },
-      },
-    },
+    historyApiFallback: true,
   },
   plugins: [
     new HtmlWebpackPlugin({


### PR DESCRIPTION
**오류 리스트**
1. 소셜 로그인 `RedirectURI `인식 불가
2. devSever의 API 요청시, `main.js` 로더 실패


**수정 목록**
<details>
<summary>소셜 로그인 RedirectURI 인식 불가</summary>

```
devServer: {
   ...,
   historyApiFallback: true
}
```
devServer의 **historyApiFallback 설정으로 해결**
</details>

<details>
<summary>devServer 구동 시, 소셜 로그인 main.js 파일 로더 실패</summary>

```
output: {
  ...,
  publicPath: '/',
},
```
```publicPath: '/'```로 수정함으로써, **모든 요청에 대해서 루트 경로(/)를 기준으로 파일을 찾도록 수정**
</details>