### PR TITLE
[Fix] useEffect 의존성 제거

### DIFF
--- a/src/components/Auth.js
+++ b/src/components/Auth.js
@@ -14,7 +14,6 @@ const Auth = () => {
     const getToken = async () => {
       try {
         const accessToken = await socialLogin(provider, code);
-
         dispatch(issue(accessToken));
         navigate('/');
       } catch (e) {
@@ -23,7 +22,8 @@ const Auth = () => {
     };
 
     getToken();
-  }, [provider, code, navigate, dispatch]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return null;
 };


### PR DESCRIPTION
[#5 **소셜 로그인시 서버로 통신이 2번 전달되던 문제 발생**]

- 소셜 로그인시 이동하는 Auth Component의 useEffect에 의존성을 제거함으로써 통신 2번 전달되던 문제를 해결